### PR TITLE
Feature/update practice mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,7 +115,7 @@ venv.bak/
 CLAUDE.md
 
 # Documentation plans (keep local only, not in git)
-**/docs/plans/
+**/plans/
 
 # Spyder project settings
 .spyderproject

--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,13 @@ ENV/
 env.bak/
 venv.bak/
 
+# Claude Code (ignore all .claude files including rules and plans)
+.claude/
+CLAUDE.md
+
+# Documentation plans (keep local only, not in git)
+**/docs/plans/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/chess_repertoire/chess_repertoire/apps/game/statistics.py
+++ b/chess_repertoire/chess_repertoire/apps/game/statistics.py
@@ -24,7 +24,6 @@ class PracticeStatistics:
             'correct_moves': 0,
             'incorrect_moves': 0,
             'hints_used': 0,
-            'restarts': 0,
             'completed': False,
             'move_history': []
         }

--- a/chess_repertoire/chess_repertoire/apps/game/statistics.py
+++ b/chess_repertoire/chess_repertoire/apps/game/statistics.py
@@ -1,0 +1,244 @@
+"""
+Practice mode statistics tracking using Django sessions.
+
+This module provides session-based statistics tracking for practice mode without
+requiring database changes. Statistics are stored in request.session['practice_stats']
+and automatically cleared when the session expires or the user navigates away.
+
+Phase 1: Session-based storage (this implementation)
+Phase 2: Future migration to database models for persistent tracking
+"""
+
+from datetime import datetime
+
+
+class PracticeStatistics:
+    """
+    Static methods for managing practice session statistics in Django sessions.
+
+    All methods operate on request.session['practice_stats'] dictionary.
+    Statistics are tracked per variation and reset when switching variations
+    or navigating away from practice mode.
+    """
+
+    SESSION_KEY = 'practice_stats'
+
+    @staticmethod
+    def initialize_stats(session, opening_name, variation_slug):
+        """
+        Initialize fresh statistics for a new practice session.
+
+        Args:
+            session: Django request.session object
+            opening_name: Name of the opening being practiced
+            variation_slug: Slug of the variation being practiced
+        """
+        now = datetime.now().isoformat()
+
+        session[PracticeStatistics.SESSION_KEY] = {
+            'variation_slug': variation_slug,
+            'opening_name': opening_name,
+            'start_time': now,
+            'last_activity': now,
+            'correct_moves': 0,
+            'incorrect_moves': 0,
+            'hints_used': 0,
+            'restarts': 0,
+            'completed': False,
+            'move_history': []
+        }
+        session.modified = True
+
+    @staticmethod
+    def get_stats(session):
+        """
+        Retrieve current statistics from session.
+
+        Args:
+            session: Django request.session object
+
+        Returns:
+            dict: Statistics dictionary or None if not found
+        """
+        return session.get(PracticeStatistics.SESSION_KEY)
+
+    @staticmethod
+    def record_move(session, move, correct):
+        """
+        Record a move attempt (correct or incorrect).
+
+        Args:
+            session: Django request.session object
+            move: The move notation (e.g., 'e4', 'Nf3')
+            correct: Boolean indicating if move was correct
+        """
+        stats = PracticeStatistics.get_stats(session)
+        if not stats:
+            return
+
+        # Update counters
+        if correct:
+            stats['correct_moves'] += 1
+        else:
+            stats['incorrect_moves'] += 1
+
+        # Update activity timestamp
+        stats['last_activity'] = datetime.now().isoformat()
+
+        # Record in move history
+        stats['move_history'].append({
+            'move': move,
+            'correct': correct,
+            'timestamp': stats['last_activity']
+        })
+
+        session[PracticeStatistics.SESSION_KEY] = stats
+        session.modified = True
+
+    @staticmethod
+    def record_hint(session):
+        """
+        Record hint usage.
+
+        Args:
+            session: Django request.session object
+        """
+        stats = PracticeStatistics.get_stats(session)
+        if not stats:
+            return
+
+        stats['hints_used'] += 1
+        stats['last_activity'] = datetime.now().isoformat()
+
+        session[PracticeStatistics.SESSION_KEY] = stats
+        session.modified = True
+
+    @staticmethod
+    def record_restart(session):
+        """
+        Record restart event (preserving cumulative statistics).
+
+        Args:
+            session: Django request.session object
+        """
+        stats = PracticeStatistics.get_stats(session)
+        if not stats:
+            return
+
+        stats['restarts'] += 1
+        stats['last_activity'] = datetime.now().isoformat()
+
+        session[PracticeStatistics.SESSION_KEY] = stats
+        session.modified = True
+
+    @staticmethod
+    def mark_completed(session):
+        """
+        Mark practice session as completed.
+
+        Args:
+            session: Django request.session object
+        """
+        stats = PracticeStatistics.get_stats(session)
+        if not stats:
+            return
+
+        stats['completed'] = True
+        stats['last_activity'] = datetime.now().isoformat()
+
+        session[PracticeStatistics.SESSION_KEY] = stats
+        session.modified = True
+
+    @staticmethod
+    def calculate_accuracy(stats):
+        """
+        Calculate accuracy percentage.
+
+        Args:
+            stats: Statistics dictionary
+
+        Returns:
+            float: Accuracy percentage (0-100), returns 0 if no moves attempted
+        """
+        if not stats:
+            return 0.0
+
+        total_moves = stats['correct_moves'] + stats['incorrect_moves']
+        if total_moves == 0:
+            return 0.0
+
+        return (stats['correct_moves'] / total_moves) * 100
+
+    @staticmethod
+    def get_duration_seconds(stats):
+        """
+        Calculate session duration in seconds.
+
+        Args:
+            stats: Statistics dictionary
+
+        Returns:
+            int: Duration in seconds
+        """
+        if not stats:
+            return 0
+
+        try:
+            start = datetime.fromisoformat(stats['start_time'])
+            end = datetime.fromisoformat(stats['last_activity'])
+            return int((end - start).total_seconds())
+        except (ValueError, KeyError):
+            return 0
+
+    @staticmethod
+    def format_duration(seconds):
+        """
+        Format duration as human-readable string.
+
+        Args:
+            seconds: Duration in seconds
+
+        Returns:
+            str: Formatted duration (e.g., "5m 23s", "1h 15m 30s", "42s")
+        """
+        if seconds < 60:
+            return f"{seconds}s"
+
+        minutes = seconds // 60
+        remaining_seconds = seconds % 60
+
+        if minutes < 60:
+            return f"{minutes}m {remaining_seconds}s"
+
+        hours = minutes // 60
+        remaining_minutes = minutes % 60
+        return f"{hours}h {remaining_minutes}m {remaining_seconds}s"
+
+    @staticmethod
+    def get_stats_summary(stats):
+        """
+        Get formatted summary for display.
+
+        Args:
+            stats: Statistics dictionary
+
+        Returns:
+            dict: Formatted summary with accuracy, duration, total_attempts
+        """
+        if not stats:
+            return {
+                'accuracy': 0.0,
+                'duration': '0s',
+                'total_attempts': 0
+            }
+
+        accuracy = PracticeStatistics.calculate_accuracy(stats)
+        duration_seconds = PracticeStatistics.get_duration_seconds(stats)
+        duration = PracticeStatistics.format_duration(duration_seconds)
+        total_attempts = stats['correct_moves'] + stats['incorrect_moves']
+
+        return {
+            'accuracy': accuracy,
+            'duration': duration,
+            'total_attempts': total_attempts
+        }

--- a/chess_repertoire/chess_repertoire/apps/game/statistics.py
+++ b/chess_repertoire/chess_repertoire/apps/game/statistics.py
@@ -1,16 +1,4 @@
-"""
-Practice mode statistics tracking using Django sessions.
-
-This module provides session-based statistics tracking for practice mode without
-requiring database changes. Statistics are stored in request.session['practice_stats']
-and automatically cleared when the session expires or the user navigates away.
-
-Phase 1: Session-based storage (this implementation)
-Phase 2: Future migration to database models for persistent tracking
-"""
-
 from datetime import datetime
-
 
 class PracticeStatistics:
     """
@@ -25,14 +13,7 @@ class PracticeStatistics:
 
     @staticmethod
     def initialize_stats(session, opening_name, variation_slug):
-        """
-        Initialize fresh statistics for a new practice session.
-
-        Args:
-            session: Django request.session object
-            opening_name: Name of the opening being practiced
-            variation_slug: Slug of the variation being practiced
-        """
+        """Initialize fresh statistics for a new practice session."""
         now = datetime.now().isoformat()
 
         session[PracticeStatistics.SESSION_KEY] = {
@@ -51,27 +32,12 @@ class PracticeStatistics:
 
     @staticmethod
     def get_stats(session):
-        """
-        Retrieve current statistics from session.
-
-        Args:
-            session: Django request.session object
-
-        Returns:
-            dict: Statistics dictionary or None if not found
-        """
+        """Retrieve current statistics from session."""
         return session.get(PracticeStatistics.SESSION_KEY)
 
     @staticmethod
     def record_move(session, move, correct):
-        """
-        Record a move attempt (correct or incorrect).
-
-        Args:
-            session: Django request.session object
-            move: The move notation (e.g., 'e4', 'Nf3')
-            correct: Boolean indicating if move was correct
-        """
+        """Record a move attempt (correct or incorrect)."""
         stats = PracticeStatistics.get_stats(session)
         if not stats:
             return
@@ -97,12 +63,7 @@ class PracticeStatistics:
 
     @staticmethod
     def record_hint(session):
-        """
-        Record hint usage.
-
-        Args:
-            session: Django request.session object
-        """
+        """Record hint usage."""
         stats = PracticeStatistics.get_stats(session)
         if not stats:
             return
@@ -114,31 +75,8 @@ class PracticeStatistics:
         session.modified = True
 
     @staticmethod
-    def record_restart(session):
-        """
-        Record restart event (preserving cumulative statistics).
-
-        Args:
-            session: Django request.session object
-        """
-        stats = PracticeStatistics.get_stats(session)
-        if not stats:
-            return
-
-        stats['restarts'] += 1
-        stats['last_activity'] = datetime.now().isoformat()
-
-        session[PracticeStatistics.SESSION_KEY] = stats
-        session.modified = True
-
-    @staticmethod
     def mark_completed(session):
-        """
-        Mark practice session as completed.
-
-        Args:
-            session: Django request.session object
-        """
+        """Mark practice session as completed."""
         stats = PracticeStatistics.get_stats(session)
         if not stats:
             return
@@ -151,15 +89,7 @@ class PracticeStatistics:
 
     @staticmethod
     def calculate_accuracy(stats):
-        """
-        Calculate accuracy percentage.
-
-        Args:
-            stats: Statistics dictionary
-
-        Returns:
-            float: Accuracy percentage (0-100), returns 0 if no moves attempted
-        """
+        """Calculate accuracy percentage."""
         if not stats:
             return 0.0
 
@@ -171,15 +101,7 @@ class PracticeStatistics:
 
     @staticmethod
     def get_duration_seconds(stats):
-        """
-        Calculate session duration in seconds.
-
-        Args:
-            stats: Statistics dictionary
-
-        Returns:
-            int: Duration in seconds
-        """
+        """Calculate session duration in seconds."""
         if not stats:
             return 0
 
@@ -192,15 +114,7 @@ class PracticeStatistics:
 
     @staticmethod
     def format_duration(seconds):
-        """
-        Format duration as human-readable string.
-
-        Args:
-            seconds: Duration in seconds
-
-        Returns:
-            str: Formatted duration (e.g., "5m 23s", "1h 15m 30s", "42s")
-        """
+        """Format duration as human-readable string."""
         if seconds < 60:
             return f"{seconds}s"
 
@@ -216,15 +130,7 @@ class PracticeStatistics:
 
     @staticmethod
     def get_stats_summary(stats):
-        """
-        Get formatted summary for display.
-
-        Args:
-            stats: Statistics dictionary
-
-        Returns:
-            dict: Formatted summary with accuracy, duration, total_attempts
-        """
+        """Get formatted summary for display."""
         if not stats:
             return {
                 'accuracy': 0.0,

--- a/chess_repertoire/chess_repertoire/apps/repertoire/mixins.py
+++ b/chess_repertoire/chess_repertoire/apps/repertoire/mixins.py
@@ -1,0 +1,78 @@
+from django.http import JsonResponse
+
+from chess_repertoire.apps.game import ChessPractice, get_current_color
+from .models import Opening, Variation
+
+
+class PracticeContextMixin:
+    """
+    Mixin providing common initialization logic for practice-related views.
+
+    Handles opening/variation retrieval, ChessPractice initialization,
+    and session state restoration.
+    """
+
+    def get_practice_context(self):
+        """Retrieves opening, variation, and initializes ChessPractice instance."""
+        opening = self.get_opening()
+        variation = self.get_variation()
+        practice = self.initialize_practice(opening, variation)
+        self.restore_session_state(practice)
+        return {
+            'opening': opening,
+            'variation': variation,
+            'practice': practice
+        }
+
+    def get_opening(self):
+        """Retrieves Opening instance from URL kwargs."""
+        return Opening.objects.get(name=self.kwargs['opn'])
+
+    def get_variation(self):
+        """Retrieves Variation instance from URL kwargs."""
+        return Variation.objects.get(slug=self.kwargs['slug'])
+
+    def initialize_practice(self, opening, variation):
+        """Creates ChessPractice instance."""
+        return ChessPractice(
+            variation.pgn_file.path,
+            opening.color,
+        )
+
+    def restore_session_state(self, practice):
+        """Restores practice state from session by running visited moves."""
+        self.request.session['moves'] = practice.run_visited_moves(
+            self.request.session.get('moves', [])
+        )
+
+
+class PracticeAjaxMixin(PracticeContextMixin):
+    """
+    Mixin specifically for AJAX practice endpoints.
+
+    Provides standardized error handling and JSON response utilities.
+    Extends PracticeContextMixin with AJAX-specific functionality.
+    """
+    
+    def dispatch(self, request, *args, **kwargs):
+        """
+        Override dispatch to provide automatic error handling for AJAX views.
+
+        Wraps view logic in try-except and returns JSON error responses
+        for any exceptions that occur.
+        """
+        try:
+            return super().dispatch(request, *args, **kwargs)
+        except Exception as e:
+            return self.json_error_response(e)
+
+    def json_error_response(self, error, status=500):
+        """Returns standardized JSON error response."""
+        return JsonResponse({'error': str(error)}, status=status)
+
+    def get_player_turn_status(self, opening):
+        """Calculates if it's player's turn based on session moves."""
+        current_color = get_current_color(
+            self.request.session.get('moves', [])
+        )
+        return opening.color == current_color

--- a/chess_repertoire/chess_repertoire/apps/repertoire/static/repertoire/css/practice_board.css
+++ b/chess_repertoire/chess_repertoire/apps/repertoire/static/repertoire/css/practice_board.css
@@ -66,3 +66,75 @@
     width: 150px;
     text-align: center;
 }
+
+/* Promotion Modal */
+#promotionModal .modal-content {
+    border: 2px solid #6D6875;
+    border-radius: 10px;
+}
+
+.promotion-piece {
+    background-color: transparent;
+    border: 2px solid transparent;
+    border-radius: 8px;
+    padding: 10px;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+    width: 100%;
+}
+
+.promotion-piece:hover {
+    background-color: rgba(109, 104, 117, 0.3);
+    border-color: #6D6875;
+    transform: scale(1.05);
+}
+
+.promotion-piece:focus {
+    outline: 2px solid #6D6875;
+    outline-offset: 2px;
+}
+
+#promotionModal {
+    z-index: 9999;
+}
+
+/* Statistics Panel */
+.stat-box {
+    padding: 5px;
+}
+
+.stat-label {
+    font-size: 11px;
+    color: #F5F3F4;
+    text-transform: uppercase;
+    font-weight: 600;
+    margin-bottom: 2px;
+}
+
+.stat-value {
+    font-size: 18px;
+    color: #DDB892;
+    font-weight: bold;
+}
+
+/* Completion Modal */
+.completion-stat {
+    background-color: #6D6875;
+    border-radius: 8px;
+    padding: 15px;
+    margin: 5px;
+}
+
+.completion-label {
+    font-size: 14px;
+    color: #DDB892;
+    text-transform: uppercase;
+    font-weight: 600;
+    margin-bottom: 5px;
+}
+
+.completion-value {
+    font-size: 32px;
+    color: #F5F3F4;
+    font-weight: bold;
+}

--- a/chess_repertoire/chess_repertoire/apps/repertoire/static/repertoire/css/practice_board.css
+++ b/chess_repertoire/chess_repertoire/apps/repertoire/static/repertoire/css/practice_board.css
@@ -1,0 +1,68 @@
+/* Highlight legal destination squares when a piece is selected */
+.highlight-legal {
+    box-shadow: inset 0 0 0 4px rgba(20, 85, 30, 0.5) !important;
+}
+
+/* Highlight hint source squares when "Show Hint" is clicked */
+.highlight-hint {
+    box-shadow: inset 0 0 0 4px rgba(129, 135, 220, 0.7) !important;
+}
+
+/* Status container for CORRECT/INCORRECT/HINT/FINISHED messages */
+#status-container {
+    min-height: 30px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* Status badges */
+.status-correct {
+    background-color: #90B36D;
+    color: #F5F3F4;
+    padding: 5px 15px;
+    border-radius: 5px;
+    font-weight: bold;
+    width: 150px;
+    text-align: center;
+}
+
+.status-incorrect {
+    background-color: #E24E51;
+    color: #F5F3F4;
+    padding: 5px 15px;
+    border-radius: 5px;
+    font-weight: bold;
+    width: 150px;
+    text-align: center;
+}
+
+.status-hint {
+    background-color: #8187DC;
+    color: #F5F3F4;
+    padding: 5px 15px;
+    border-radius: 5px;
+    font-weight: bold;
+    width: 150px;
+    text-align: center;
+}
+
+.status-finished {
+    background-color: #7F5539;
+    color: #F5F3F4;
+    padding: 5px 15px;
+    border-radius: 5px;
+    font-weight: bold;
+    width: 150px;
+    text-align: center;
+}
+
+.status-checkmate {
+    background-color: #6D6875;
+    color: #F5F3F4;
+    padding: 5px 15px;
+    border-radius: 5px;
+    font-weight: bold;
+    width: 150px;
+    text-align: center;
+}

--- a/chess_repertoire/chess_repertoire/apps/repertoire/static/repertoire/js/practice_board.js
+++ b/chess_repertoire/chess_repertoire/apps/repertoire/static/repertoire/js/practice_board.js
@@ -1,0 +1,333 @@
+// Global variables
+var game = new Chess();
+var board = null;
+var isPlayerTurn = true;
+var practiceFinished = false;
+var squareToHighlight = null;
+
+// Initialize board when page loads
+$(document).ready(function() {
+    initBoard();
+    loadPositionFromServer();
+
+    // Event handlers for buttons
+    $('#restart-btn').click(function() {
+        restartPractice();
+    });
+
+    $('#hint-btn').click(function() {
+        showHint();
+    });
+});
+
+// Initialize chessboard.js
+function initBoard() {
+    var config = {
+        draggable: true,
+        position: 'start',
+        onDragStart: onDragStart,
+        onDrop: onDrop,
+        onSnapEnd: onSnapEnd,
+        pieceTheme: pieceTheme,
+        orientation: playerColor === 'w' ? 'white' : 'black'
+    };
+
+    board = Chessboard('chessboard', config);
+}
+
+// Custom piece theme to use existing PNG images
+function pieceTheme(piece) {
+    var pieceMap = {
+        'wP': 'white_pawn.png',
+        'wN': 'white_knight.png',
+        'wB': 'white_bishop.png',
+        'wR': 'white_rook.png',
+        'wQ': 'white_queen.png',
+        'wK': 'white_king.png',
+        'bP': 'black_pawn.png',
+        'bN': 'black_knight.png',
+        'bB': 'black_bishop.png',
+        'bR': 'black_rook.png',
+        'bQ': 'black_queen.png',
+        'bK': 'black_king.png'
+    };
+
+    return '/static/repertoire/pieces/' + pieceMap[piece];
+}
+
+// Validate drag start
+function onDragStart(source, piece, position, orientation) {
+    // Don't allow moves if game is over or not player's turn
+    if (practiceFinished || !isPlayerTurn) {
+        return false;
+    }
+
+    // Don't allow opponent's pieces to be dragged
+    if ((playerColor === 'w' && piece.search(/^b/) !== -1) ||
+        (playerColor === 'b' && piece.search(/^w/) !== -1)) {
+        return false;
+    }
+
+    // Highlight legal destination squares
+    highlightLegalMoves(source);
+}
+
+// Handle piece drop
+function onDrop(source, target) {
+    // Remove legal move highlights
+    removeHighlights();
+
+    // Check if the move is legal in chess.js
+    var move = game.move({
+        from: source,
+        to: target,
+        promotion: 'q' // Always promote to queen for now
+    });
+
+    // If illegal move in chess.js, snap back
+    if (move === null) {
+        return 'snapback';
+    }
+
+    // Disable player moves while validating
+    isPlayerTurn = false;
+
+    // Extract SAN notation
+    var sanMove = move.san;
+
+    // Validate with server
+    validateMoveWithServer(sanMove, move);
+}
+
+// Update board position after snap animation
+function onSnapEnd() {
+    board.position(game.fen());
+}
+
+// Highlight legal moves for a piece
+function highlightLegalMoves(square) {
+    var moves = game.moves({
+        square: square,
+        verbose: true
+    });
+
+    // Highlight each legal destination square
+    for (var i = 0; i < moves.length; i++) {
+        highlightSquare(moves[i].to);
+    }
+}
+
+// Add highlight class to a square
+function highlightSquare(square) {
+    var $square = $('#chessboard .square-' + square);
+    $square.addClass('highlight-legal');
+}
+
+// Remove all highlights
+function removeHighlights() {
+    $('#chessboard .square-55d63').removeClass('highlight-legal');
+    $('#chessboard .square-55d63').removeClass('highlight-hint');
+}
+
+// Validate move with server via AJAX
+function validateMoveWithServer(sanMove, moveObj) {
+    $.ajax({
+        url: validateMoveUrl,
+        type: 'POST',
+        contentType: 'application/json',
+        headers: {
+            'X-CSRFToken': csrfToken
+        },
+        data: JSON.stringify({
+            move: sanMove
+        }),
+        success: function(response) {
+            if (response.correct) {
+                // Show correct status
+                updateStatus('correct');
+
+                // Check if there's an opponent move
+                if (response.opponent_move) {
+                    // Wait 500ms then make opponent's move
+                    setTimeout(function() {
+                        makeOpponentMove(response.opponent_move);
+                    }, 500);
+                } else {
+                    // Practice finished
+                    practiceFinished = true;
+                    updateStatus('finished');
+                }
+            } else {
+                // Move is incorrect - undo it
+                game.undo();
+                board.position(game.fen());
+                updateStatus('incorrect');
+                isPlayerTurn = true;
+            }
+        },
+        error: function(xhr, status, error) {
+            console.error('Error validating move:', error);
+            alert('Error validating move. Please try again.');
+            // Undo move on error
+            game.undo();
+            board.position(game.fen());
+            isPlayerTurn = true;
+        }
+    });
+}
+
+// Make opponent's move
+function makeOpponentMove(sanMove) {
+    // Execute move in chess.js
+    var move = game.move(sanMove);
+
+    if (move === null) {
+        console.error('Invalid opponent move:', sanMove);
+        return;
+    }
+
+    // Update board with animation
+    board.position(game.fen());
+
+    // Check for checkmate
+    if (game.game_over()) {
+        if (game.in_checkmate()) {
+            practiceFinished = true;
+            updateStatus('checkmate');
+        } else {
+            practiceFinished = true;
+            updateStatus('finished');
+        }
+    } else {
+        // Re-enable player turn
+        isPlayerTurn = true;
+    }
+}
+
+// Load current position from server
+function loadPositionFromServer() {
+    $.ajax({
+        url: getPositionUrl,
+        type: 'GET',
+        success: function(response) {
+            // Load FEN into chess.js and board
+            game.load(response.fen);
+            board.position(response.fen);
+
+            // Set player turn flag
+            isPlayerTurn = response.is_player_turn;
+
+            // Check if finished
+            if (response.finished) {
+                practiceFinished = true;
+                updateStatus('finished');
+            } else if (response.is_checkmate) {
+                practiceFinished = true;
+                updateStatus('checkmate');
+            }
+        },
+        error: function(xhr, status, error) {
+            console.error('Error loading position:', error);
+            alert('Error loading board position.');
+        }
+    });
+}
+
+// Show hint - highlight legal moves
+function showHint() {
+    if (practiceFinished) {
+        return;
+    }
+
+    removeHighlights();
+
+    $.ajax({
+        url: getHintsUrl,
+        type: 'POST',
+        headers: {
+            'X-CSRFToken': csrfToken
+        },
+        success: function(response) {
+            // Convert square numbers to square names
+            var legalMoves = response.legal_moves;
+
+            // Highlight source squares
+            for (var i = 0; i < legalMoves.length; i++) {
+                var fromSquare = squareNumToName(legalMoves[i].from);
+                var $square = $('#chessboard .square-' + fromSquare);
+                $square.addClass('highlight-hint');
+            }
+
+            updateStatus('hint');
+        },
+        error: function(xhr, status, error) {
+            console.error('Error getting hints:', error);
+            alert('Error getting hints.');
+        }
+    });
+}
+
+// Restart practice
+function restartPractice() {
+    removeHighlights();
+
+    $.ajax({
+        url: restartUrl,
+        type: 'POST',
+        headers: {
+            'X-CSRFToken': csrfToken
+        },
+        success: function(response) {
+            // Load starting FEN
+            game.load(response.fen);
+            board.position(response.fen);
+
+            // Reset flags
+            practiceFinished = false;
+            isPlayerTurn = response.is_player_turn;
+
+            // Clear status
+            $('#status-container').html('');
+        },
+        error: function(xhr, status, error) {
+            console.error('Error restarting:', error);
+            alert('Error restarting practice.');
+        }
+    });
+}
+
+// Update status indicator
+function updateStatus(status) {
+    var html = '';
+
+    switch(status) {
+        case 'correct':
+            html = '<div class="status-correct">CORRECT</div>';
+            break;
+        case 'incorrect':
+            html = '<div class="status-incorrect">INCORRECT</div>';
+            break;
+        case 'hint':
+            html = '<div class="status-hint">HINT</div>';
+            break;
+        case 'finished':
+            html = '<div class="status-finished">FINISHED</div>';
+            break;
+        case 'checkmate':
+            html = '<div class="status-checkmate">CHECKMATE</div>';
+            break;
+    }
+
+    $('#status-container').html(html);
+}
+
+// Convert python-chess square number to square name (e.g., 0 -> a1)
+function squareNumToName(squareNum) {
+    var files = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+    var ranks = ['1', '2', '3', '4', '5', '6', '7', '8'];
+
+    var file = files[squareNum % 8];
+    var rank = ranks[Math.floor(squareNum / 8)];
+
+    return file + rank;
+}

--- a/chess_repertoire/chess_repertoire/apps/repertoire/templates/repertoire/practice.html
+++ b/chess_repertoire/chess_repertoire/apps/repertoire/templates/repertoire/practice.html
@@ -64,65 +64,25 @@
 			</div>
 			<div class="col">
 				<div class="container pt-3 pb-1 text-center rounded">
-					{{ board }}
+					<div id="chessboard" style="width: 500px; margin: 0 auto;"></div>
 				</div>
-				<form method="POST">
-					{% csrf_token %}
-					<div class="container text-center" style="max-width: 500px;">
-						<div class="form-row">
-							<div class="row px-2 py-1">
-								{% if correct == 'correct' %}
-									<div class="col">
-										<input class="form-control" type="text" name="move" placeholder="Enter a Move">
-									</div>
-									<div class="col pt-1">
-										<div class="container rounded text-center" style="background-color: #90B36D; width: 150px; height: 30px">
-											<h6 class="pt-1 text-light"><strong>CORRECT</strong></h6>
-										</div>
-									</div>
-								{% elif correct == 'incorrect' %}
-									<div class="col">
-										<input class="form-control" type="text" name="move" placeholder="Enter a Move">
-									</div>
-									<div class="col pt-1">
-										<div class="container rounded text-center" style="background-color: #E24E51; width: 150px; height: 30px">
-											<h6 class="pt-1 text-light"><strong>INCORRECT</strong></h6>
-										</div>
-									</div>
-								{% elif correct == 'hint' %}
-									<div class="col">
-										<input class="form-control" type="text" name="move" placeholder="Enter a Move">
-									</div>
-									<div class="col pt-1">
-										<div class="container rounded text-center" style="background-color: #8187DC; width: 150px; height: 30px">
-											<h6 class="pt-1 text-light"><strong>HINT</strong></h6>
-										</div>
-									</div>
-								{% elif correct == 'finished' %}
-									<div class="col pt-1">
-										<div class="container rounded text-center" style="background-color: #7F5539; width: 150px; height: 30px">
-											<h6 class="pt-1 text-light"><strong>FINISHED</strong></h6>
-										</div>
-									</div>
-								{% else %}
-									<div class="col">
-										<input class="form-control" type="text" name="move" placeholder="Enter a Move">
-									</div>
-								{% endif %}
+				<div class="container text-center" style="max-width: 500px;">
+					<div class="form-row">
+						<div class="row px-2 py-1">
+							<div class="col pt-1">
+								<div id="status-container"></div>
 							</div>
-							<div class="row px-3 py-1">
-								<div class="col text-center">
-									<button type="submit" value="restart" name="restart" class="btn text-light mx-2" style="width: 150px; background-color: #6D6875;" role="button">Restart</button>
-								</div>
-								{% if correct != 'finished' %}
-									<div class="col text-center">
-										<button type="submit" value="hint" name="hint" class="btn text-light mx-2" style="width: 150px; background-color: #6D6875;" role="button">Show Hint</button>
-									</div>
-								{% endif %}
+						</div>
+						<div class="row px-3 py-1">
+							<div class="col text-center">
+								<button id="restart-btn" class="btn text-light mx-2" style="width: 150px; background-color: #6D6875;" role="button">Restart</button>
+							</div>
+							<div class="col text-center">
+								<button id="hint-btn" class="btn text-light mx-2" style="width: 150px; background-color: #6D6875;" role="button">Show Hint</button>
 							</div>
 						</div>
 					</div>
-				</form>
+				</div>
 			</div>
 			<div class="col pt-3">
 				{% if is_checkmate %}
@@ -190,4 +150,29 @@
 		</div>
 	</div>
 </div>
+
+<!-- JavaScript Libraries for Drag-and-Drop Chess -->
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/@chrisoakman/chessboardjs@1.0.0/dist/chessboard-1.0.0.min.css">
+<script src="https://unpkg.com/@chrisoakman/chessboardjs@1.0.0/dist/chessboard-1.0.0.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.10.3/chess.min.js"></script>
+
+<!-- Custom Practice Board Styles -->
+<link rel="stylesheet" href="{% static 'repertoire/css/practice_board.css' %}">
+
+<!-- Django variables for JavaScript -->
+<script>
+    var playerColor = '{{ opening.color|yesno:"b,w" }}';
+    var openingName = '{{ opening.name }}';
+    var variationSlug = '{{ variation.slug }}';
+    var csrfToken = '{{ csrf_token }}';
+    var validateMoveUrl = '{% url "repertoire:practice_validate_move" opening.name variation.slug %}';
+    var getPositionUrl = '{% url "repertoire:practice_get_position" opening.name variation.slug %}';
+    var getHintsUrl = '{% url "repertoire:practice_get_hints" opening.name variation.slug %}';
+    var restartUrl = '{% url "repertoire:practice_restart" opening.name variation.slug %}';
+</script>
+
+<!-- Custom Practice Board Logic -->
+<script src="{% static 'repertoire/js/practice_board.js' %}"></script>
+
 {% endblock %}

--- a/chess_repertoire/chess_repertoire/apps/repertoire/templates/repertoire/practice.html
+++ b/chess_repertoire/chess_repertoire/apps/repertoire/templates/repertoire/practice.html
@@ -7,6 +7,37 @@
 {% block content %}
 <div class="container mt-3 mx-auto" style="max-width: 850px;">
 	<h4 class="text-center" style="color: #F5F3F4;">Practicing {{ variation.name }} from {{ opening.name }}</h4>
+
+	<!-- Statistics Panel -->
+	<div class="container mt-2 mb-3 pt-2 pb-2 text-center rounded" style="background-color: #6D6875; max-width: 850px;">
+		<div class="row">
+			<div class="col-3">
+				<div class="stat-box">
+					<div class="stat-label">Accuracy</div>
+					<div class="stat-value" id="stat-accuracy">--%</div>
+				</div>
+			</div>
+			<div class="col-3">
+				<div class="stat-box">
+					<div class="stat-label">Correct</div>
+					<div class="stat-value" id="stat-correct">0</div>
+				</div>
+			</div>
+			<div class="col-3">
+				<div class="stat-box">
+					<div class="stat-label">Incorrect</div>
+					<div class="stat-value" id="stat-incorrect">0</div>
+				</div>
+			</div>
+			<div class="col-3">
+				<div class="stat-box">
+					<div class="stat-label">Hints</div>
+					<div class="stat-value" id="stat-hints">0</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
 	<div class="container mt-3 mb-3 px-0 rounded" style="background-color:#DDB892; height: 620px;">
 		<div class="row">
 			<div class="col pt-3">
@@ -144,11 +175,84 @@
 			<div class="col text-center">
 				<a href="{% url 'repertoire:opening_variations' opening.slug %}" class="btn text-light" style="width: 200px; background-color: #6D6875;" role="button">Other Variations</a>
 			</div>
-			<div class="col text-center">
-				<a href="{% url 'repertoire:review' opening.name variation.slug %}" class="btn text-light" style="width: 200px; background-color: #6D6875;" role="button">Review</a>
+		</div>
+	</div>
+</div>
+
+<!-- Completion Modal -->
+<div class="modal fade" id="completionModal" tabindex="-1" data-bs-backdrop="static" data-bs-keyboard="false">
+	<div class="modal-dialog modal-dialog-centered">
+		<div class="modal-content" style="background-color: #DDB892;">
+			<div class="modal-header" style="border-bottom: 2px solid #6D6875;">
+				<h5 class="modal-title" style="color: #6D6875;">Practice Complete!</h5>
+			</div>
+			<div class="modal-body text-center">
+				<h3 style="color: #6D6875;">Well Done!</h3>
+				<div class="row mt-3 justify-content-center">
+					<div class="col-8">
+						<div class="completion-stat">
+							<div class="completion-label">Accuracy</div>
+							<div class="completion-value" id="final-accuracy">--%</div>
+						</div>
+					</div>
+				</div>
+				<div class="row mt-3">
+					<div class="col-4">
+						<small style="color: #6D6875;">Correct: <span id="final-correct">0</span></small>
+					</div>
+					<div class="col-4">
+						<small style="color: #6D6875;">Incorrect: <span id="final-incorrect">0</span></small>
+					</div>
+					<div class="col-4">
+						<small style="color: #6D6875;">Hints: <span id="final-hints">0</span></small>
+					</div>
+				</div>
+			</div>
+			<div class="modal-footer" style="border-top: 2px solid #6D6875;">
+				<button type="button" class="btn text-light" style="background-color: #6D6875;" onclick="restartPractice()">Practice Again</button>
+				<button type="button" class="btn text-light" style="background-color: #6D6875;" data-bs-dismiss="modal">Close</button>
 			</div>
 		</div>
 	</div>
+</div>
+
+<!-- Promotion Dialog Modal -->
+<div class="modal fade" id="promotionModal" tabindex="-1" data-bs-backdrop="static" data-bs-keyboard="false">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content" style="background-color: #DDB892;">
+      <div class="modal-header border-0">
+        <h5 class="modal-title" style="color: #F5F3F4;">Choose Promotion Piece</h5>
+      </div>
+      <div class="modal-body">
+        <div class="row text-center">
+          <div class="col-6 mb-3">
+            <button type="button" class="btn promotion-piece" data-piece="q">
+              <img id="promo-queen-img" src="" alt="Queen" width="80" height="80">
+              <div style="color: #F5F3F4; margin-top: 5px;">Queen</div>
+            </button>
+          </div>
+          <div class="col-6 mb-3">
+            <button type="button" class="btn promotion-piece" data-piece="r">
+              <img id="promo-rook-img" src="" alt="Rook" width="80" height="80">
+              <div style="color: #F5F3F4; margin-top: 5px;">Rook</div>
+            </button>
+          </div>
+          <div class="col-6">
+            <button type="button" class="btn promotion-piece" data-piece="b">
+              <img id="promo-bishop-img" src="" alt="Bishop" width="80" height="80">
+              <div style="color: #F5F3F4; margin-top: 5px;">Bishop</div>
+            </button>
+          </div>
+          <div class="col-6">
+            <button type="button" class="btn promotion-piece" data-piece="n">
+              <img id="promo-knight-img" src="" alt="Knight" width="80" height="80">
+              <div style="color: #F5F3F4; margin-top: 5px;">Knight</div>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <!-- JavaScript Libraries for Drag-and-Drop Chess -->
@@ -170,6 +274,7 @@
     var getPositionUrl = '{% url "repertoire:practice_get_position" opening.name variation.slug %}';
     var getHintsUrl = '{% url "repertoire:practice_get_hints" opening.name variation.slug %}';
     var restartUrl = '{% url "repertoire:practice_restart" opening.name variation.slug %}';
+    var getStatisticsUrl = '{% url "repertoire:practice_get_statistics" opening.name variation.slug %}';
 </script>
 
 <!-- Custom Practice Board Logic -->

--- a/chess_repertoire/chess_repertoire/apps/repertoire/urls.py
+++ b/chess_repertoire/chess_repertoire/apps/repertoire/urls.py
@@ -14,5 +14,10 @@ urlpatterns = [
     path('<slug:slug>/new_variation/', views.NewVariation.as_view(), name='new_variation'),
     path('<str:opn>/<slug:slug>/modify/', views.ModifyVariation.as_view(), name='modify_variation'),
     path('<str:opn>/<slug:slug>/review/', views.ReviewVariation.as_view(), name='review'),
-    path('<str:opn>/<slug:slug>/practice/', views.PracticeVariation.as_view(), name='practice')
+    path('<str:opn>/<slug:slug>/practice/', views.PracticeVariation.as_view(), name='practice'),
+    # AJAX endpoints for drag-and-drop practice mode
+    path('<str:opn>/<slug:slug>/practice/validate_move/', views.PracticeValidateMove.as_view(), name='practice_validate_move'),
+    path('<str:opn>/<slug:slug>/practice/get_position/', views.PracticeGetPosition.as_view(), name='practice_get_position'),
+    path('<str:opn>/<slug:slug>/practice/get_hints/', views.PracticeGetHints.as_view(), name='practice_get_hints'),
+    path('<str:opn>/<slug:slug>/practice/restart/', views.PracticeRestart.as_view(), name='practice_restart')
 ]

--- a/chess_repertoire/chess_repertoire/apps/repertoire/urls.py
+++ b/chess_repertoire/chess_repertoire/apps/repertoire/urls.py
@@ -19,5 +19,6 @@ urlpatterns = [
     path('<str:opn>/<slug:slug>/practice/validate_move/', views.PracticeValidateMove.as_view(), name='practice_validate_move'),
     path('<str:opn>/<slug:slug>/practice/get_position/', views.PracticeGetPosition.as_view(), name='practice_get_position'),
     path('<str:opn>/<slug:slug>/practice/get_hints/', views.PracticeGetHints.as_view(), name='practice_get_hints'),
-    path('<str:opn>/<slug:slug>/practice/restart/', views.PracticeRestart.as_view(), name='practice_restart')
+    path('<str:opn>/<slug:slug>/practice/restart/', views.PracticeRestart.as_view(), name='practice_restart'),
+    path('<str:opn>/<slug:slug>/practice/get_statistics/', views.PracticeGetStatistics.as_view(), name='practice_get_statistics')
 ]

--- a/chess_repertoire/chess_repertoire/settings.py
+++ b/chess_repertoire/chess_repertoire/settings.py
@@ -22,7 +22,7 @@ BASE_DIR = Path(__file__).resolve().parent
 SECRET_KEY = 'django-insecure-5a3mncb=5vt0jzhp^nrx=yoki8%pwnjt2m&11%m-sd-o3*jfvk'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 ALLOWED_HOSTS = ['127.0.0.1']
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,7 @@ django-autoslug==1.9.8
 django-cleanup==5.2.0
 django-filter==21.1
 django-widget-tweaks==1.4.8
+hydra-core == 1.1.0
 Pillow==8.3.1
 chess==1.8.0
+tqdm==4.67.1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements a modern drag-and-drop practice mode with session-based stats and supporting backend endpoints.
> 
> - Adds `practice_board.js` and `practice_board.css` for chessboard.js/chess.js UI, legal-move/hint highlights, promotion dialog, status badges, and completion modal
> - Reworks `practice.html` to use the interactive board and control buttons (restart, hint) and live stats panel
> - Introduces `PracticeStatistics` for session-tracked accuracy, attempts, hints, duration; exposes `practice_get_statistics` endpoint
> - Adds AJAX views and URLs: validate move, get position, get hints, restart, get statistics; includes `PracticeContextMixin` and `PracticeAjaxMixin` for shared setup and JSON error handling
> - Models `Opening` and `Variation` now override `delete()` to remove their media directories when empty or after cascade
> - Enables DEBUG in settings and updates `.gitignore`; adds `hydra-core` and `tqdm` to requirements
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e4cedb26fce246769e5e35017205d6281a480ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->